### PR TITLE
Routing default wildcard, enhanced reset functionality

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -14,4 +14,9 @@ export const routes: Route[] = [
     redirectTo: "home",
     pathMatch: "full",
   },
+  {
+    path: "**",
+    redirectTo: "home",
+    pathMatch: "full",
+  }
 ];

--- a/src/app/checklist/checklist.component.ts
+++ b/src/app/checklist/checklist.component.ts
@@ -26,7 +26,6 @@ import { ChecklistItemListComponent } from "./ui/checklist-item-list.component";
       *ngIf="checklist() as checklist"
       [checklist]="checklist"
       (addItem)="checklistItemBeingEdited.set({})"
-      (resetChecklist)="cis.reset$.next($event)"
     />
 
     <app-checklist-item-list
@@ -34,6 +33,8 @@ import { ChecklistItemListComponent } from "./ui/checklist-item-list.component";
       (toggle)="cis.toggle$.next($event)"
       (delete)="cis.remove$.next($event)"
       (edit)="checklistItemBeingEdited.set($event)"
+      (resetChecklist)="cis.reset$.next($event)"
+
     />
 
     <app-modal [isOpen]="!!checklistItemBeingEdited()">

--- a/src/app/checklist/ui/checklist-item-header.component.ts
+++ b/src/app/checklist/ui/checklist-item-header.component.ts
@@ -9,14 +9,11 @@ import { Checklist } from "../../shared/interfaces/checklist";
       <h1>
         {{ checklist.title }}
       </h1>
-
-      <button (click)="resetChecklist.emit(checklist.id)">Reset</button>
       <button (click)="addItem.emit()">Add item</button>
     </header>
   `,
 })
 export class ChecklistItemHeaderComponent {
   @Input() checklist!: Checklist;
-  @Output() resetChecklist = new EventEmitter<string>();
   @Output() addItem = new EventEmitter<void>();
 }

--- a/src/app/checklist/ui/checklist-item-list.component.ts
+++ b/src/app/checklist/ui/checklist-item-list.component.ts
@@ -12,6 +12,7 @@ import { ChecklistItem } from "../../shared/interfaces/checklist-item";
   imports: [CommonModule],
   selector: "app-checklist-item-list",
   template: `
+  <button *ngIf="hasCheckedItems()" (click)="reset()">Reset Checklist Items</button>
     <ul>
       <li *ngFor="let item of checklistItems; trackBy: trackByFn">
         <span *ngIf="item.checked">[DONE]</span>
@@ -33,6 +34,7 @@ export class ChecklistItemListComponent {
   @Output() toggle = new EventEmitter<string>();
   @Output() delete = new EventEmitter<string>();
   @Output() edit = new EventEmitter<ChecklistItem>();
+  @Output() resetChecklist = new EventEmitter<string>();
 
   toggleItem(itemId: string) {
     this.toggle.emit(itemId);
@@ -40,5 +42,16 @@ export class ChecklistItemListComponent {
 
   trackByFn(index: number, item: ChecklistItem) {
     return item.id;
+  }
+  hasCheckedItems() {
+    return this.checklistItems.some(item => item.checked);
+  }
+
+  getFirstCheckedItem(): ChecklistItem | undefined {
+    return this.checklistItems.find(item => item.checked);
+  }
+  reset() {
+    const cli = this.getFirstCheckedItem();
+    if(cli) this.resetChecklist.emit(cli.checklistId);
   }
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -27,7 +27,7 @@ import { ChecklistListComponent } from "./ui/checklist-list.component";
     <app-modal [isOpen]="!!checklistBeingEdited()">
       <ng-template>
         <app-form-modal
-          title="test"
+          title="Add Checklist"
           [formGroup]="checklistForm"
           (close)="checklistBeingEdited.set(null)"
           (save)="


### PR DESCRIPTION
Routing now has a wildcard that will take users to the home route if an incorrect route is manually entered.

Reset button checks array for some() checked item, if we have one, show the reset button.

Reset takes first checkListItem that's checked and provides the checklistId when resetting.